### PR TITLE
Improve file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,40 @@ csso: {
   dev: {
     src: '../files/css/dev/app.css',
     dest:'../files/css/dev/app.min.css',
-    restructure: false
-  }
-  prod: {
-    // Override 'src' if 'dest' is undefiend.
-    src: '../files/css/app.css',
+    options: {
+      restructure: true
+    }
   }
 }
 ```
 
-You can write with the "compact" format.
+You can also be written in such these format.
 
 ```javascript
+// files format
 csso: {
-  // 'dest' : 'src'
-  'foo.min.css' : 'foo.css',
-  'bar.min.css' : 'bar.css',
-  'min.min.css' : 'baz.css'
+  dist: {
+    files: {
+      // dest       : src
+      'foo.min.css' : 'foo.css',
+      'bar.min.css' : 'bar.css',
+      'baz.min.css' : 'baz.css'
+    },
+    options: {
+      restructure: false
+    }
+  }
+}
+
+// individual dest
+csso: {
+  dev: {
+    src : ['src/css/foo.css', 'src/css/bar.css', 'src/css/baz.css'],
+    dest: 'dist/css/*',
+    options: {
+      restructure: true
+    }
+  }
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "csso": "~1.3.4",
-    "gzip-js": "~0.3.1"
+    "gzip-js": "~0.3.1",
+    "grunt-lib-contrib": "~0.4.0"
   },
   "devDependencies": {
     "grunt": "~0.3.17"


### PR DESCRIPTION
Please see [grunt-csso/README.md at modern-format · ahomu/grunt-csso · GitHub](https://github.com/ahomu/grunt-csso/blob/modern-format/README.md#an-example-setup).

---

`restructure` option has been moved `options`.

```
csso: {
  dev: {
    src: '../files/css/dev/app.css',
    dest:'../files/css/dev/app.min.css',
    options: {
      restructure: false
    }
  }
}
```

Please note that backward compatibility.
