### PR TITLE
maxmin report refactored to follow general convention

### DIFF
--- a/tasks/csso.js
+++ b/tasks/csso.js
@@ -62,10 +62,10 @@ module.exports = function (grunt) {
         proceed = banner + proceed;
 
         grunt.file.write(file.dest, proceed);
-        grunt.log.writeln('File ' + chalk.green(file.dest) + ' created.');
         if (options.report) {
-          grunt.log.writeln(maxmin(original, proceed, options.report === 'gzip'));
+          var report =(maxmin(original, proceed, options.report === 'gzip'));
         }
+        grunt.log.writeln('File ' + chalk.cyan(file.dest) + ' created' + ((report) ? ': ' + report : '.'));
       }
     });
   });


### PR DESCRIPTION
Generally all grunt plugins that use maxmin publish the final report on the end of the same line.
Also file.dest colour was changed from green to cyan for the same reason
Result:
![github](https://cloud.githubusercontent.com/assets/1016321/4181144/95b36048-370f-11e4-98a6-992c80b5a3d3.png)
